### PR TITLE
Add support for preserving XF headers from upstream

### DIFF
--- a/conf.d/commons/common-headers.conf
+++ b/conf.d/commons/common-headers.conf
@@ -25,18 +25,23 @@ add_header X-Request-Id $requestId;
 proxy_set_header X-Request-Id  $requestId;
 
 # -----------
-#  X-Real-IP
+# X-Real-IP
 # -----------
 set $proxy_remote_addr $http_x_real_ip;
 set_if_empty $proxy_remote_addr $remote_addr;
 proxy_set_header X-Real-IP $proxy_remote_addr;
 
 # -----------------
-#  X-Forwarded-For
-#  X-Forwarded-Host
+# X-Forwarded-For
 # -----------------
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-proxy_set_header X-Forwarded-Host $host;
+
+# ----------------
+# X-Forwarded-Host
+# ----------------
+set $proxy_forwarded_host $http_x_forwarded_host;
+set_if_empty $proxy_forwarded_host $host;
+proxy_set_header X-Forwarded-Host $proxy_forwarded_host;
 
 # -----------------
 # X-Forwarded-Port

--- a/scripts/lua/routing.lua
+++ b/scripts/lua/routing.lua
@@ -95,7 +95,11 @@ function _M.processCall(dataStore)
       if requestScheme == nil or requestScheme == "" then
         requestScheme = ngx.var.scheme
       end
-      local requestUrl = utils.concatStrings({requestScheme, "://", ngx.var.host})
+      local requestHost = ngx.req.get_headers()["X-Forwarded-Host"]
+      if requestHost == nil or requestHost == "" then
+        requestHost = ngx.var.host
+      end
+      local requestUrl = utils.concatStrings({requestScheme, "://", requestHost})
       local prefix = ngx.req.get_headers()["X-Forwarded-Prefix"]
       if prefix ~= nil and prefix ~= "" then
         requestUrl = utils.concatStrings({requestUrl, prefix})

--- a/scripts/lua/routing.lua
+++ b/scripts/lua/routing.lua
@@ -46,6 +46,8 @@ local _M = {}
 
 --- Main function that handles parsing of invocation details and carries out implementation
 function _M.processCall(dataStore)
+  -- Get request headers
+  local requestHeaders = ngx.req.get_headers()
   -- Get resource object from redis
   local tenantId = ngx.var.tenant
 
@@ -91,20 +93,20 @@ function _M.processCall(dataStore)
       -- Set backend upstream and uri
       backendRouting.setRoute(opFields.backendUrl, gatewayPath)
       -- Set gateway url as request header
-      local requestScheme = ngx.req.get_headers()["X-Forwarded-Proto"]
+      local requestScheme = requestHeaders["X-Forwarded-Proto"]
       if requestScheme == nil or requestScheme == "" then
         requestScheme = ngx.var.scheme
       end
-      local requestHost = ngx.req.get_headers()["X-Forwarded-Host"]
+      local requestHost = requestHeaders["X-Forwarded-Host"]
       if requestHost == nil or requestHost == "" then
         requestHost = ngx.var.host
       end
       local requestUrl = utils.concatStrings({requestScheme, "://", requestHost})
-      local prefix = ngx.req.get_headers()["X-Forwarded-Prefix"]
+      local prefix = requestHeaders["X-Forwarded-Prefix"]
       if prefix ~= nil and prefix ~= "" then
         requestUrl = utils.concatStrings({requestUrl, prefix})
       end
-      local requestUri = ngx.req.get_headers()["X-Forwarded-Uri"]
+      local requestUri = requestHeaders["X-Forwarded-Uri"]
       if requestUri == nil or requestUri == "" then
         requestUri = ngx.var.request_uri
       end
@@ -114,7 +116,7 @@ function _M.processCall(dataStore)
         parsePolicies(dataStore, opFields.policies, key)
       end
       -- Log updated request headers/body info to access logs
-      if ngx.req.get_headers()["x-debug-mode"] == "true" then
+      if requestHeaders["x-debug-mode"] == "true" then
         setRequestLogs()
       end
       dataStore:close()

--- a/scripts/lua/routing.lua
+++ b/scripts/lua/routing.lua
@@ -104,7 +104,11 @@ function _M.processCall(dataStore)
       if prefix ~= nil and prefix ~= "" then
         requestUrl = utils.concatStrings({requestUrl, prefix})
       end
-      ngx.req.set_header("X-Forwarded-Url", utils.concatStrings({requestUrl, ngx.var.request_uri}))
+      local requestUri = ngx.req.get_headers()["X-Forwarded-Uri"]
+      if requestUri == nil or requestUri == "" then
+        requestUri = ngx.var.request_uri
+      end
+      ngx.req.set_header("X-Forwarded-Url", utils.concatStrings({requestUrl, requestUri}))
       -- Parse policies
       if opFields.policies ~= nil then
         parsePolicies(dataStore, opFields.policies, key)


### PR DESCRIPTION
- Set `X-Forwarded-Host` based on upstream headers. If header is present in the request, it will honor the value coming from upstream.
- Override the `request_uri` portion of `X-Forwarded-Url`, if `X-Forwarded-Uri` is present in upstream request.