### PR TITLE
Fix getUriPath logic to ignore API tenant base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,11 +104,7 @@ Then make changes to any configuration file ( i.e. `api-gateway.conf` ), save it
 
 ### Testing
 
- First install the necessary dependencies:
+ To build the test image and run unit tests
  ```
-  make test-build
- ```
- Then, run the unit tests:
- ```
-  make test-run
+  make test
  ```

--- a/tests/scripts/lua/policies/backendRouting.lua
+++ b/tests/scripts/lua/policies/backendRouting.lua
@@ -28,17 +28,29 @@ describe('Testing backend routing module', function()
   end)
 
   it('should work without override', function()
-    ngx.var.request_uri = "/api/23bc46b1-71f6-4ed5-8c54-816aa4f8c502/hello/world"
-    backendRouting.setRoute("https://localhost:3233/api/v1/web/guest/default/hello2.json", "hello/world")
+    ngx.var.gatewayPath = 'hello/world'
+    ngx.var.tenant = '23bc46b1-71f6-4ed5-8c54-816aa4f8c502'
+    ngx.var.request_uri = '/api/' .. ngx.var.tenant .. '/' .. ngx.var.gatewayPath
+    backendRouting.setRoute("https://localhost:3233/api/v1/web/guest/default/hello2.json", ngx.var.gatewayPath)
     assert.are.same(ngx.var.upstream, 'https://localhost:3233')
     assert.are.same(ngx.var.backendUrl, 'https://localhost:3233/api/v1/web/guest/default/hello2.json')
   end)
 
   it('should work with override', function()
-      ngx.var.request_uri = "/api/23bc46b1-71f6-4ed5-8c54-816aa4f8c502/hello/world"
-      backendRouting.setRouteWithOverride("https://localhost:3233/api/v1/web/guest/default/hello2.json", "hello/world",
-         "http://172.0.0.1:3456")
-      assert.are.same(ngx.var.upstream, 'http://172.0.0.1:3456')
-      assert.are.same(ngx.var.backendUrl, 'http://172.0.0.1:3456/api/v1/web/guest/default/hello2.json')
-    end)
+    ngx.var.gatewayPath = 'hello/world'
+    ngx.var.tenant = '23bc46b1-71f6-4ed5-8c54-816aa4f8c502'
+    ngx.var.request_uri = '/api/' .. ngx.var.tenant .. '/' .. ngx.var.gatewayPath
+    backendRouting.setRouteWithOverride("https://localhost:3233/api/v1/web/guest/default/hello2.json", ngx.var.gatewayPath,
+       "http://172.0.0.1:3456")
+    assert.are.same(ngx.var.upstream, 'http://172.0.0.1:3456')
+    assert.are.same(ngx.var.backendUrl, 'http://172.0.0.1:3456/api/v1/web/guest/default/hello2.json')
+  end)
+
+  it('should match URI properly, ignoring API tenant base path', function()
+    ngx.var.gatewayPath = 'api'
+    ngx.var.tenant = '23bc46b1-71f6-4ed5-8c54-816aa4f8c502'
+    ngx.var.request_uri = '/api/' .. ngx.var.tenant .. '/' .. ngx.var.gatewayPath
+    actual = backendRouting.getUriPath('/api')
+    assert.are.same(actual, '/api')
+  end)
 end)


### PR DESCRIPTION
Connects to #362 

This change will ignore `/api/<tenant>` when matching the original URI and computing the backend URI. 

- Strip `/api/<tenant>` when computing backend URI
- Extract out `getUriPath` for unit testing
- Add unit test
- Update README.md "Testing" make cmd 

PTAL: @mhamann @rabbah 