### PR TITLE
fix(http): Use HTTP 1.1 for upstreams

### DIFF
--- a/conf.d/managed_endpoints.conf
+++ b/conf.d/managed_endpoints.conf
@@ -80,6 +80,7 @@ server {
             routing.processCall(ds.init())
         }
 
+        proxy_http_version 1.1;
         proxy_pass $upstream;
         header_filter_by_lua_block {
             local cors = require "cors"


### PR DESCRIPTION
Fixes #368 