### PR TITLE
fix(core): upstream openresty fixes; lua global scope pollution

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ CONTRIBUTING.md
 Dockerfile
 Makefile
 README.md
+tools/

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,12 @@ env:
   global:
     - secure: "c8XNwdOryMVJUGLzWv+AzUQaS0Yt7uUmGqw+5/K7o7zmpux7Q5H7OU3jni2kOr+ZoIldsmTnnG7m1N9D8qUjD64KaAfEC0ybo04kDraezVMghUEV8LWMpSRRlAFpzQeVC8IcSiUEXM0H8E6Y09jGMnLKqyFUWAlDB60n0x2rfK/IPU+x4/h+6Y5XpYqaNtujoUf/2XVkrOeRcEhVZQJAwsRtA8HjRUy7PRB/9kepTSln9QzRZYd6v4F1qUKgZhlWNRUXWRbhrNK/z6T7jSlHjY44yvse4fBbie+EsuImtOHnDuTA4XXQlbc0gGVvD3sYYf2CBMxeeE+UTbRPLxgml+uUIviWKt/PKB5qUwQyLKP/Rzr1qv5RryrX0xWoqCrVsaCe0fkh0vUks0AYlzhm1CNK/g1If+qZ6R0GMjawVUbCunhDi1vJlP5PmniIoLpVwLa6XoMYJKtfngGm2763y00ktVGGL1gDtnm0lDuhkinIxOzieh8aRpYDBX6zZZ/n20LzDO/5l0CGErKPgzzt9vRPiQNoGxqC90jtsin+XkOxF9erk0QYt/St7/Qa1R0E+0dA2bHqxz2SWz3cjcc4Cw8/DW3SLFjaONvs6aQyHkrL2LJabARMMgGmf68P5nJrPy56c3gV8jXe7CVaV+5nClT1HYgWSEIna6oyzo8kzFk="
     - secure: "dM0paMW2d4U4U7OwbnrTjdOqDnvo+nce9r7h+qTbYfbuJe0fpRkHCrxcB//8ESkMrPTr0EDExCxvaywY8pqeVVJbykNswdyze1SWYk6lbUvXTpSrKqp0J0a/FtVjfamc1aMv4c6KIDKh4vIcgK4xrjXj68COCS6uIcFhETNUy5bxH8T2BOJzyf/iWOF7oduXUV/VGNcWnhkPdoPh8xtpmBJ6ZTWQ01MriZ/28hvzgyh1OjJFWCJZ+OZoIDQVPb/jnfPXU4Wk/G/LEPJcBgvN4qSMr2lm3Iq29V0Ltrsx8rrYADO7trCm6qyEQK9TLKfywaYIcm/D9FJ8F4WBHtIeJ3PLY3518L3iZ+Ngd6QTnd0FI6hrG7rpoD/0dz4e//9d3tSsjbh/1BiQwXXTnPyaUjN3C92k4GyITYJTVL5f6evzsTneT6Plj1vWC0E52d1oqVOZDgrWMYZEHdYvpUJTQqclMNhu5SMIYAPqVvibqupcmAh5B+UDr6UvYT/hUAC/d3hyjfHgouRoluJ1mutND88QjDw6UWmXXjHqRSCI6OI5NDZczl/aqz7nPFyTaIe9EibTdZa5LC8fN+Am9MTRxJAv8HXt0zKe5FqHijSvFcVxYlhwlIZg7ShbPh+X2Hnh/JMjx0z/7ujkBRYfmAQW53SBy8Tv/Zv69nCz8eOFOUk="
+    - LUA=lua5.1
 
 before_install:
   - ./tools/travis/scan.sh
   - ./tools/travis/setup.sh
+  - source ./tools/travis/setenv_lua.sh
 
 script:
   - ./tools/lua-releng -L -e scripts/lua/**/*.lua

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ before_install:
   - ./tools/travis/setup.sh
 
 script:
+  - ./tools/lua-releng -L -e scripts/lua/**/*.lua
   - make test
   - ./tools/travis/build.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 
 # apigateway
 #
-# VERSION               1.15.8.3
+# VERSION               1.17.8.2
 #
 # From https://hub.docker.com/_/alpine/
 #
@@ -37,7 +37,7 @@ RUN apk update && \
     && rm -rf /var/cache/apk/*
 
 # openresty build
-ENV OPENRESTY_VERSION=1.15.8.3 \
+ENV OPENRESTY_VERSION=1.17.8.2 \
     PCRE_VERSION=8.37 \
     TEST_NGINX_VERSION=0.24 \
     OPM_VERSION=0.0.5 \

--- a/scripts/lua/api_gateway_init.lua
+++ b/scripts/lua/api_gateway_init.lua
@@ -24,18 +24,20 @@ local _M = {}
 --- Loads a lua gracefully. If the module doesn't exist the exception is caught, logged and the execution continues
 -- @param module path to the module to be loaded
 --
-local function loadrequire(module)
-    ngx.log(ngx.DEBUG, "Loading module [" .. tostring(module) .. "]")
+local function loadrequire(mod)
+    ngx.log(ngx.DEBUG, "Loading module [" .. tostring(mod) .. "]")
     local function requiref(module)
         require(module)
     end
 
-    local res = pcall(requiref, module)
+    local res = pcall(requiref, mod)
     if not (res) then
-        ngx.log(ngx.WARN, "Could not load module [", module, "].")
+        ngx.log(ngx.WARN, "Could not load module [", mod, "].")
         return nil
     end
-    return require(module)
+    return require(mod)
 end
+
+_M.loadrequire = loadrequire
 
 ngx.apiGateway = _M

--- a/scripts/lua/lib/dataStore.lua
+++ b/scripts/lua/lib/dataStore.lua
@@ -34,7 +34,7 @@ end
 
 function DataStore:setSnapshotId(tenant)
   self.snapshotId = self.impl.getSnapshotId(self.ds, tenant)
-  self:lockSnapshot(snapshotId)
+  self:lockSnapshot(self.snapshotId)
   if self.snapshotId == ngx.null then
     self.snapshotId = nil
   end
@@ -159,7 +159,7 @@ end
 
 function DataStore:getSubscriptions(artifactId, tenantId)
   self:singleInit()
-  return self.impl.deleteSubscription(self.ds, key, self.snapshotId)
+  return self.impl.getSubscriptions(self.ds, artifactId, tenantId, self.snapshotId)
 end
 
 function DataStore:healthCheck()

--- a/scripts/lua/lib/request.lua
+++ b/scripts/lua/lib/request.lua
@@ -27,7 +27,7 @@ local _Request = {}
 --- Error function to call when request is malformed
 -- @param code error code
 -- @param msg error message
-function err(code, msg)
+local function err(code, msg)
   ngx.header.content_type = "application/json; charset=utf-8"
   ngx.status = code
   local errObj = cjson.encode({
@@ -41,7 +41,7 @@ end
 --- Function to call when request is successful
 -- @param code status code
 -- @param obj JSON encoded object to return
-function success(code, obj)
+local function success(code, obj)
   ngx.status = code
   if obj ~= nil then
     ngx.say(obj)

--- a/scripts/lua/lib/utils.lua
+++ b/scripts/lua/lib/utils.lua
@@ -26,7 +26,7 @@ local _Utils = {}
 -- @return concatenated string
 function _Utils.concatStrings(list)
   local t = {}
-  for k,v in ipairs(list) do
+  for _, v in ipairs(list) do
     t[#t+1] = tostring(v)
   end
   return table.concat(t)
@@ -84,7 +84,7 @@ end
 -- @param table table to check
 -- @param element element to check in table
 function _Utils.tableContains(table, element)
-  for i, value in pairs(table) do
+  for _, value in pairs(table) do
     if value == element then
       return true
     end
@@ -96,7 +96,7 @@ end
 -- @param table table to check
 -- @param requiredFields list of required fields
 function _Utils.tableContainsAll(table, requiredFields)
-  for i, field in ipairs(requiredFields) do
+  for _, field in ipairs(requiredFields) do
     if not table[field] then
       return false, { statusCode = 400, message = _Utils.concatStrings({"\"", field, "\" missing from request body."}) }
     end

--- a/scripts/lua/lib/utils.lua
+++ b/scripts/lua/lib/utils.lua
@@ -67,7 +67,7 @@ end
 -- @return concatenated string of (?<path_pathParam>(\\w+))
 function _Utils.convertTemplatedPathParam(m)
   local x = m:gsub("{", ""):gsub("}", "")
-  return concatStrings({"(?<path_" , x , ">([a-zA-Z0-9\\-\\s\\_\\%]*))"})
+  return _Utils.concatStrings({"(?<path_" , x , ">([a-zA-Z0-9\\-\\s\\_\\%]*))"})
 end
 
 --- Generate random uuid

--- a/scripts/lua/management/lib/resources.lua
+++ b/scripts/lua/management/lib/resources.lua
@@ -19,7 +19,6 @@
 -- Management interface for resources for the gateway
 
 local utils = require "lib/utils"
-local cjson = require "cjson"
 local REDIS_FIELD = "resources"
 local _M = {}
 

--- a/scripts/lua/management/lib/subscriptions.lua
+++ b/scripts/lua/management/lib/subscriptions.lua
@@ -18,7 +18,6 @@
 --- @module subscriptions
 -- Management interface for subscriptions for the gateway
 
-local redis = require "lib/redis"
 local utils = require "lib/utils"
 
 local _M = {}

--- a/scripts/lua/management/lib/tenants.lua
+++ b/scripts/lua/management/lib/tenants.lua
@@ -115,18 +115,18 @@ local function applyPagingToAPIs(apiList, queryParams)
   else
     limit = skip + limit - 1
   end
-  local apis  = {}
+  local apis_obj  = {}
   local idx   = 0
   for i = skip, limit do
-    apis[idx] = apiList[i]
+    apis_obj[idx] = apiList[i]
     idx = idx + 1
   end
-  return apis
+  return apis_obj
 end
 
 --- Filter apis based on query paramters
 -- @param queryParams query parameters to filter apis
-local function filterTenantAPIs(id, apis, queryParams)
+local function filterTenantAPIs(id, apis_obj, queryParams)
   local basePath = queryParams['filter[where][basePath]']
   basePath = basePath == nil and queryParams['basePath'] or basePath
   local name = queryParams['filter[where][name]']
@@ -137,7 +137,7 @@ local function filterTenantAPIs(id, apis, queryParams)
   end
   -- filter apis
   local apiList = {}
-  for k, v in pairs(apis) do
+  for k, v in pairs(apis_obj) do
     if k%2 == 0 then
       local api = cjson.decode(v)
       if api.tenantId == id and
@@ -156,14 +156,14 @@ end
 -- @param id tenant id
 -- @param queryParams object containing optional query parameters
 function _M.getTenantAPIs(dataStore, id, queryParams)
-  local apis = dataStore:getAllAPIs()
+  local apis_obj = dataStore:getAllAPIs()
   local apiList
   if next(queryParams) ~= nil then
-    apiList = filterTenantAPIs(id, apis, queryParams);
+    apiList = filterTenantAPIs(id, apis_obj, queryParams);
   end
   if apiList == nil then
     apiList = {}
-    for k, v in pairs(apis) do
+    for k, v in pairs(apis_obj) do
       if k%2 == 0 then
         local decoded = cjson.decode(v)
         if decoded.tenantId == id then

--- a/scripts/lua/management/lib/validation.lua
+++ b/scripts/lua/management/lib/validation.lua
@@ -62,7 +62,7 @@ local function checkOperations(operations)
     end
     -- Check required fields
     local requiredFields = {"backendMethod", "backendUrl"}
-    for k, v in pairs(requiredFields) do
+    for _, v in pairs(requiredFields) do
       if verbObj[v] == nil then
         return false, { statusCode = 400, message = utils.concatStrings({"Missing field '", v, "' for '", verb, "' operation."}) }
       end

--- a/scripts/lua/management/routes/apis.lua
+++ b/scripts/lua/management/routes/apis.lua
@@ -19,17 +19,12 @@
 -- Management interface for apis for the gateway
 
 local cjson = require "cjson"
-local dataStore = require "lib/dataStore"
 local utils = require "lib/utils"
 local request = require "lib/request"
 local apis = require "management/lib/apis"
 local tenants = require "management/lib/tenants"
 local swagger = require "management/lib/swagger"
 local validation = require "management/lib/validation"
-
-local REDIS_HOST = os.getenv("REDIS_HOST")
-local REDIS_PORT = os.getenv("REDIS_PORT")
-local REDIS_PASS = os.getenv("REDIS_PASS")
 
 local _M = {}
 

--- a/scripts/lua/management/routes/subscriptions.lua
+++ b/scripts/lua/management/routes/subscriptions.lua
@@ -19,14 +19,9 @@
 -- Management interface for subscriptions for the gateway
 
 local cjson = require "cjson"
-local redis = require "lib/redis"
 local utils = require "lib/utils"
 local request = require "lib/request"
 local subscriptions = require "management/lib/subscriptions"
-
-local REDIS_HOST = os.getenv("REDIS_HOST")
-local REDIS_PORT = os.getenv("REDIS_PORT")
-local REDIS_PASS = os.getenv("REDIS_PASS")
 
 local _M = {}
 

--- a/scripts/lua/management/routes/tenants.lua
+++ b/scripts/lua/management/routes/tenants.lua
@@ -19,13 +19,9 @@
 -- Management interface for tenants for the gateway
 
 local cjson = require "cjson"
-local redis = require "lib/redis"
 local utils = require "lib/utils"
 local request = require "lib/request"
 local tenants = require "management/lib/tenants"
-local REDIS_HOST = os.getenv("REDIS_HOST")
-local REDIS_PORT = os.getenv("REDIS_PORT")
-local REDIS_PASS = os.getenv("REDIS_PASS")
 
 local _M = {};
 

--- a/scripts/lua/oauth/app-id.lua
+++ b/scripts/lua/oauth/app-id.lua
@@ -63,7 +63,7 @@ function _M.process(dataStore, token, securityObj)
   for _, v in ipairs(keys) do
     key = v
   end
-  local result = cjose.validateJWS(token, cjson.encode(key))
+  result = cjose.validateJWS(token, cjson.encode(key))
   if not result then
     request.err(401, 'The token signature did not match any known JWK.')
     return nil

--- a/scripts/lua/oauth/facebook.lua
+++ b/scripts/lua/oauth/facebook.lua
@@ -23,7 +23,6 @@ local _M = {}
 
 local function exchangeOAuthToken(dataStore, token, facebookAppToken)
   local http = require 'resty.http'
-  local request = require "lib/request"
   local httpc = http.new()
 
   local request_options = {

--- a/scripts/lua/oauth/github.lua
+++ b/scripts/lua/oauth/github.lua
@@ -16,7 +16,6 @@
 --
 
 -- A Proxy for Github OAuth API
-local cjson = require "cjson"
 local http = require "resty.http"
 local request = require "lib/request"
 local cjson = require "cjson"

--- a/scripts/lua/oauth/google.lua
+++ b/scripts/lua/oauth/google.lua
@@ -20,7 +20,6 @@ local cjson = require "cjson"
 local http = require "resty.http"
 local request = require "lib/request"
 local utils = require "lib/utils"
-local redis = require "lib/redis"
 
 local _M = {}
 function _M.process (dataStore, token)

--- a/scripts/lua/oauth/google.lua
+++ b/scripts/lua/oauth/google.lua
@@ -29,7 +29,7 @@ function _M.process (dataStore, token)
 
   local httpc = http.new()
   if result ~= ngx.null then
-    json_resp = cjson.decode(result)
+    local json_resp = cjson.decode(result)
     ngx.header['X-OIDC-Sub'] = json_resp['sub']
     ngx.header['X-OIDC-Email'] = json_resp['email']
     ngx.header['X-OIDC-Scope'] = json_resp['scope']

--- a/scripts/lua/oauth/mock.lua
+++ b/scripts/lua/oauth/mock.lua
@@ -19,7 +19,6 @@
 local cjson = require "cjson"
 local _M = {}
 function _M.process (red, token)
-  local result
   if token == "test" then
     local goodResult = [[
       {

--- a/scripts/lua/policies/backendRouting.lua
+++ b/scripts/lua/policies/backendRouting.lua
@@ -26,6 +26,14 @@ local backendOverride = os.getenv("BACKEND_HOST")
 
 local _M = {}
 
+local function setUpstream(u)
+  local upstream = utils.concatStrings({u.scheme, '://', u.host})
+  if u.port ~= nil and u.port ~= '' then
+    upstream = utils.concatStrings({upstream, ':', u.port})
+  end
+  ngx.var.upstream = upstream
+end
+
 --- Set upstream based on the backendUrl
 function _M.setRoute(backendUrl, gatewayPath)
   _M.setRouteWithOverride(backendUrl, gatewayPath, backendOverride)
@@ -107,14 +115,6 @@ function _M.getUriPath(backendPath)
   else
     return utils.concatStrings({backendPath, incomingPath})
   end
-end
-
-function setUpstream(u)
-  local upstream = utils.concatStrings({u.scheme, '://', u.host})
-  if u.port ~= nil and u.port ~= '' then
-    upstream = utils.concatStrings({upstream, ':', u.port})
-  end
-  ngx.var.upstream = upstream
 end
 
 return _M

--- a/scripts/lua/policies/mapping.lua
+++ b/scripts/lua/policies/mapping.lua
@@ -144,7 +144,7 @@ end
 -- @param d The destination object that we will move all found parameters to.
 local function transformAllParams(s, d)
   if s == 'query' then
-    for k, v in pairs(query) do
+    for k in pairs(query) do
       local t = {}
       t.from = {}
       t.from.name = k
@@ -156,7 +156,7 @@ local function transformAllParams(s, d)
       removeParam(t)
     end
   elseif s == 'header' then
-    for k, v in pairs(headers) do
+    for k in pairs(headers) do
       local t = {}
       t.from = {}
       t.from.name = k
@@ -168,7 +168,7 @@ local function transformAllParams(s, d)
       removeParam(t)
     end
   elseif s == 'body' then
-    for k, v in pairs(body) do
+    for k in pairs(body) do
       local t = {}
       t.from = {}
       t.from.name = k
@@ -180,7 +180,7 @@ local function transformAllParams(s, d)
       removeParam(t)
     end
   elseif s == 'path' then
-    for k, v in pairs(path) do
+    for k in pairs(path) do
       local t = {}
       t.from = {}
       t.from.name = k
@@ -229,7 +229,7 @@ end
 -- @param map The mapping object that contains details about request tranformations
 local function processMap(map)
   getRequestParams()
-  for k, v in pairs(map) do
+  for _, v in pairs(map) do
     if v.action == "insert" then
       insertParam(v)
     elseif v.action == "remove" then

--- a/scripts/lua/policies/rateLimit.lua
+++ b/scripts/lua/policies/rateLimit.lua
@@ -26,7 +26,7 @@ local _M = {}
 -- @param dataStore the datastore object
 -- @param obj rateLimit object containing interval, rate, scope, subscription fields
 -- @param apiKey optional api key to use if subscription is set to true
-function limit(dataStore, obj, apiKey)
+local function limit(dataStore, obj, apiKey)
   local rate = obj.interval / obj.rate
   local tenantId = ngx.var.tenant
   local gatewayPath = ngx.var.gatewayPath

--- a/scripts/lua/policies/security.lua
+++ b/scripts/lua/policies/security.lua
@@ -24,7 +24,7 @@ local utils = require "lib/utils"
 --- Allow or block a request by calling a loaded security policy
 -- @param dataStore the datastore object
 -- @param securityObj an object out of the security array in a given tenant / api / resource
-function process(dataStore, securityObj)
+local function process(dataStore, securityObj)
   local ok, result = pcall(require, utils.concatStrings({'policies/security/', securityObj.type}))
   if not ok then
     ngx.log(ngx.ERR, 'An unexpected error ocurred while processing the security policy: ' .. securityObj.type)

--- a/scripts/lua/policies/security/apiKey.lua
+++ b/scripts/lua/policies/security/apiKey.lua
@@ -20,7 +20,6 @@
 
 local utils = require "lib/utils"
 local request = require "lib/request"
-local logger = require "lib/logger"
 
 local _M = {}
 

--- a/scripts/lua/policies/security/clientSecret.lua
+++ b/scripts/lua/policies/security/clientSecret.lua
@@ -21,7 +21,6 @@ local _M = {}
 
 local utils = require "lib/utils"
 local request = require "lib/request"
-local logger = require "lib/logger"
 
 --- Validate that the subscription exists in the dataStore
 -- @param dataStore the datastore object

--- a/scripts/lua/policies/security/clientSecret.lua
+++ b/scripts/lua/policies/security/clientSecret.lua
@@ -19,76 +19,9 @@
 -- Check a subscription with a client id and a hashed secret
 local _M = {}
 
-local dataStore = require "lib/dataStore"
 local utils = require "lib/utils"
 local request = require "lib/request"
-
-local REDIS_HOST = os.getenv("REDIS_HOST")
-local REDIS_PORT = os.getenv("REDIS_PORT")
-local REDIS_PASS = os.getenv("REDIS_PASS")
-
---- Process function main entry point for the security block.
---  Takes 2 headers and decides if the request should be allowed based on a hashed secret key
---@param dataStore the datastore object
---@param securityObj the security object loaded from nginx.conf
---@return a string representation of what this looks like in redis :clientsecret:clientid:hashed secret
-function process(dataStore, securityObj)
-  local result = processWithHashFunction(dataStore, securityObj, utils.hash)
-end
-
---- In order to properly test this functionallity, I use this function to do all of the business logic with injected dependencies
--- Takes 2 headers and decides if the request should be allowed based on a hashed secret key
--- @param dataStore the datastore object
--- @param securityObj the security configuration for the tenant/resource/api we are verifying
--- @param hashFunction the function used to perform the hash of the api secret
-function processWithHashFunction(dataStore, securityObj, hashFunction)
-  -- pull the configuration from nginx
-  local tenant = ngx.var.tenant
-  local gatewayPath = ngx.var.gatewayPath
-  local apiId = ngx.var.apiId
-  local scope = securityObj.scope
-  local queryString = ngx.req.get_uri_args()
-  local location = (securityObj.location == nil) and 'header' or securityObj.location
-  local clientId = nil
-  local clientSecret = nil
-
-  -- allow support for custom names in query or header
-  local clientIdName = (securityObj.idFieldName == nil) and 'X-Client-ID' or securityObj.idFieldName
-  if location == "header" then
-    clientId = ngx.var[utils.concatStrings({'http_', clientIdName}):gsub("-", "_")]
-  end
-  if location == "query" then
-    clientId = queryString[clientIdName]
-  end
--- if they didn't supply whatever name this is configured to require, error out
-  if clientId == nil or clientId == '' then
-    request.err(401, clientIdName .. " required")
-    return false
-  end
-
--- allow support for custom names in query or header
-  local clientSecretName = (securityObj.secretFieldName == nil) and 'X-Client-Secret' or securityObj.secretFieldName
-  _G.clientSecretName = clientSecretName:lower()
-  if location == "header" then
-    clientSecret = ngx.var[utils.concatStrings({'http_', clientSecretName}):gsub("-","_")]
-  end
-  if location == "query" then
-    clientSecret = queryString[clientSecretName]
-  end
--- if they didn't supply whatever name this is configured to require, error out
-  if clientSecret == nil or clientSecret == '' then
-    request.err(401, clientSecretName .. " required")
-    return false
-  end
-
--- hash the secret
-  local result = validate(dataStore, tenant, gatewayPath, apiId, scope, clientId, hashFunction(clientSecret))
-  if result == nil then
-    request.err(401, "Secret mismatch or not subscribed to this api.")
-  end
-  ngx.var.apiKey = clientId
-  return result
-end
+local logger = require "lib/logger"
 
 --- Validate that the subscription exists in the dataStore
 -- @param dataStore the datastore object
@@ -98,24 +31,90 @@ end
 -- @param scope which values should we be using to find the location of the secret
 -- @param clientId the subscribed client id
 -- @param clientSecret the hashed client secret
-function validate(dataStore, tenant, gatewayPath, apiId, scope, clientId, clientSecret)
--- Open connection to redis or use one from connection pool
+local function validate(dataStore, tenant, gatewayPath, apiId, scope, clientId, clientSecret)
+  -- Open connection to redis or use one from connection pool
   local k
-  if scope == 'tenant' then
-    k = utils.concatStrings({'subscriptions:tenant:', tenant})
-  elseif scope == 'resource' then
-    k = utils.concatStrings({'subscriptions:tenant:', tenant, ':resource:', gatewayPath})
-  elseif scope == 'api' then
-    k = utils.concatStrings({'subscriptions:tenant:', tenant, ':api:', apiId})
+  if scope == "tenant" then
+    k = utils.concatStrings({"subscriptions:tenant:", tenant})
+  elseif scope == "resource" then
+    k = utils.concatStrings({"subscriptions:tenant:", tenant, ":resource:", gatewayPath})
+  elseif scope == "api" then
+    k = utils.concatStrings({"subscriptions:tenant:", tenant, ":api:", apiId})
   end
   -- using the same key location in redis, just using :clientsecret: instead of :key:
-  k = utils.concatStrings({k, ':clientsecret:', clientId, ':', clientSecret})
+  k = utils.concatStrings({k, ":clientsecret:", clientId, ":", clientSecret})
   if dataStore:exists(k) == 1 then
     return k
   else
     return nil
   end
 end
+
+--- In order to properly test this functionallity, I use this function to do all of the business logic with injected dependencies
+-- Takes 2 headers and decides if the request should be allowed based on a hashed secret key
+-- @param dataStore the datastore object
+-- @param securityObj the security configuration for the tenant/resource/api we are verifying
+-- @param hashFunction the function used to perform the hash of the api secret
+local function processWithHashFunction(dataStore, securityObj, hashFunction)
+  -- pull the configuration from nginx
+  local tenant = ngx.var.tenant
+  local gatewayPath = ngx.var.gatewayPath
+  local apiId = ngx.var.apiId
+  local scope = securityObj.scope
+  local queryString = ngx.req.get_uri_args()
+  local location = (securityObj.location == nil) and "header" or securityObj.location
+  local clientId = nil
+  local clientSecret = nil
+
+  ngx.log(ngx.DEBUG, "Processing CLIENT_SECRET security policy")
+
+  -- allow support for custom names in query or header
+  local clientIdName = (securityObj.idFieldName == nil) and "X-Client-ID" or securityObj.idFieldName
+  if location == "header" then
+    clientId = ngx.var[utils.concatStrings({"http_", clientIdName}):gsub("-", "_")]
+  end
+  if location == "query" then
+    clientId = queryString[clientIdName]
+  end
+  -- if they didn't supply whatever name this is configured to require, error out
+  if clientId == nil or clientId == "" then
+    request.err(401, clientIdName .. " required")
+    return false
+  end
+
+  -- allow support for custom names in query or header
+  local clientSecretName = (securityObj.secretFieldName == nil) and "X-Client-Secret" or securityObj.secretFieldName
+  ngx.ctx.clientSecretName = clientSecretName:lower()
+  if location == "header" then
+    clientSecret = ngx.var[utils.concatStrings({"http_", clientSecretName}):gsub("-", "_")]
+  end
+  if location == "query" then
+    clientSecret = queryString[clientSecretName]
+  end
+  -- if they didn't supply whatever name this is configured to require, error out
+  if clientSecret == nil or clientSecret == "" then
+    request.err(401, clientSecretName .. " required")
+    return false
+  end
+
+  -- hash the secret
+  local result = validate(dataStore, tenant, gatewayPath, apiId, scope, clientId, hashFunction(clientSecret))
+  if result == nil then
+    request.err(401, "Secret mismatch or not subscribed to this api.")
+  end
+  ngx.var.apiKey = clientId
+  return result
+end
+
+--- Process function main entry point for the security block.
+--  Takes 2 headers and decides if the request should be allowed based on a hashed secret key
+--@param dataStore the datastore object
+--@param securityObj the security object loaded from nginx.conf
+--@return a string representation of what this looks like in redis :clientsecret:clientid:hashed secret
+local function process(dataStore, securityObj)
+  return processWithHashFunction(dataStore, securityObj, utils.hash)
+end
+
 _M.processWithHashFunction = processWithHashFunction
 _M.process = process
 return _M

--- a/scripts/lua/routing.lua
+++ b/scripts/lua/routing.lua
@@ -45,7 +45,7 @@ local _M = {}
 
 local function setRequestLogs()
   local requestHeaders = ngx.req.get_headers()
-  for k, v in pairs(requestHeaders) do
+  for k in pairs(requestHeaders) do
     if k == 'authorization' or k == ngx.ctx.clientSecretName then
       requestHeaders[k] = '[redacted]'
     end
@@ -60,7 +60,7 @@ end
 -- @param obj List of policies containing a type and value field. This function reads the type field and routes it appropriately.
 -- @param apiKey optional subscription api key
 local function parsePolicies(dataStore, obj, apiKey)
-  for k, v in pairs (obj) do
+  for _, v in pairs (obj) do
     if v.type == 'reqMapping' then
       mapping.processMap(v.value)
     elseif v.type == 'rateLimit' then
@@ -94,7 +94,7 @@ function _M.processCall(dataStore)
     dataStore:setSnapshotId(tenantId)
   end
   local gatewayPath = ngx.var.gatewayPath
-  local i, j = ngx.var.request_uri:find("/api/([^/]+)")
+  local _ , j = ngx.var.request_uri:find("/api/([^/]+)")
   ngx.var.analyticsUri = ngx.var.request_uri:sub(j+1)
   if ngx.req.get_headers()["x-debug-mode"] == "true" then
     setRequestLogs()
@@ -222,7 +222,7 @@ function _M.slowLookup(resourceKeys, tenant, path, redisKey, cfRedisKey)
   end
   -- Construct a table of redisKeys based on number of slashes in the path
   local keyTable = {}
-  for i, key in pairs(resourceKeys) do
+  for _, key in pairs(resourceKeys) do
     local _, count = string.gsub(key, "/", "")
     -- handle cases where resource path is "/"
     if count == 1 and string.sub(key, -1) == "/" then

--- a/scripts/lua/routing.lua
+++ b/scripts/lua/routing.lua
@@ -25,7 +25,6 @@ end
 local url = require "url"
 local utils = require "lib/utils"
 local request = require "lib/request"
-local logger = require "lib/logger"
 -- load policies
 local security = require "policies/security"
 local mapping = require "policies/mapping"

--- a/tools/lua-releng
+++ b/tools/lua-releng
@@ -1,0 +1,104 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Getopt::Std;
+
+my (@luas, @tests);
+
+my %opts;
+getopts('Lse', \%opts) or die "Usage: lua-releng [-L] [-s] [-e] [files]\n";
+
+my $silent = $opts{s};
+my $stop_on_error = $opts{e};
+my $no_long_line_check = $opts{L};
+
+my $check_lua_ver = "luac -v | awk '{print\$2}'| grep 5.1";
+my $output = `$check_lua_ver`;
+if ($output eq '') {
+    die "ERROR: lua-releng ONLY supports Lua 5.1!\n";
+}
+
+if ($#ARGV != -1) {
+    @luas = @ARGV;
+
+} else {
+    @luas = map glob, qw{ *.lua lib/*.lua lib/*/*.lua lib/*/*/*.lua lib/*/*/*/*.lua lib/*/*/*/*/*.lua };
+    if (-d 't') {
+        @tests = map glob, qw{ t/*.t t/*/*.t t/*/*/*.t };
+    }
+}
+
+for my $f (sort @luas) {
+    process_file($f);
+}
+
+for my $t (@tests) {
+    blank(qq{grep -H -n --color -E '\\--- ?(ONLY|LAST)' $t});
+}
+# p: prints a string to STDOUT appending \n
+# w: prints a string to STDERR appending \n
+# Both respect the $silent value
+sub p { print "$_[0]\n" if (!$silent) }
+sub w { warn  "$_[0]\n" if (!$silent) }
+
+# blank: runs a command and looks at the output. If the output is not
+# blank it is printed (and the program dies if stop_on_error is 1)
+sub blank {
+    my ($command) = @_;
+    if ($stop_on_error) {
+        my $output = `$command`;
+        if ($output ne '') {
+            die $output;
+        }
+    } else {
+        system($command);
+    }
+}
+
+my $version;
+sub process_file {
+    my $file = shift;
+    # Check the sanity of each .lua file
+    open my $in, $file or
+        die "ERROR: Can't open $file for reading: $!\n";
+    my $found_ver;
+    while (<$in>) {
+        my ($ver, $skipping);
+        if (/(?x) (?:_VERSION|version) \s* = .*? ([\d\.]*\d+) (.*? SKIP)?/) {
+            my $orig_ver = $ver = $1;
+            $found_ver = 1;
+            $skipping = $2;
+            $ver =~ s{^(\d+)\.(\d{3})(\d{3})$}{join '.', int($1), int($2), int($3)}e;
+            w("$file: $orig_ver ($ver)");
+            last;
+
+        } elsif (/(?x) (?:_VERSION|version) \s* = \s* ([a-zA-Z_]\S*)/) {
+            w("$file: $1");
+            $found_ver = 1;
+            last;
+        }
+
+        if ($ver and $version and !$skipping) {
+            if ($version ne $ver) {
+                die "$file: $ver != $version\n";
+            }
+        } elsif ($ver and !$version) {
+            $version = $ver;
+        }
+    }
+    if (!$found_ver) {
+        w("WARNING: No \"_VERSION\" or \"version\" field found in `$file`.");
+    }
+    close $in;
+
+    p("Checking use of Lua global variables in file $file...");
+    p("\top no.\tline\tinstruction\targs\t; code");
+    blank("luac -p -l $file | grep -E '[GS]ETGLOBAL' | grep -vE '\\<(require|type|tostring|error|ngx|ndk|jit|setmetatable|getmetatable|string|table|io|os|print|tonumber|math|pcall|xpcall|unpack|pairs|ipairs|assert|module|package|coroutine|[gs]etfenv|next|rawget|rawset|rawlen|select)\\>'");
+    unless ($no_long_line_check) {
+        p("Checking line length exceeding 80...");
+        blank("grep -H -n -E --color '.{81}' $file");
+    }
+}
+ 

--- a/tools/travis/platform.sh
+++ b/tools/travis/platform.sh
@@ -1,0 +1,15 @@
+if [ -z "${PLATFORM:-}" ]; then
+  PLATFORM=$TRAVIS_OS_NAME;
+fi
+
+if [ "$PLATFORM" == "osx" ]; then
+  PLATFORM="macosx";
+fi
+
+if [ -z "$PLATFORM" ]; then
+  if [ "$(uname)" == "Linux" ]; then
+    PLATFORM="linux";
+  else
+    PLATFORM="macosx";
+  fi;
+fi

--- a/tools/travis/platform.sh
+++ b/tools/travis/platform.sh
@@ -1,3 +1,25 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2014 Alexey Melnichuk
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 if [ -z "${PLATFORM:-}" ]; then
   PLATFORM=$TRAVIS_OS_NAME;
 fi

--- a/tools/travis/scancodeExclusions
+++ b/tools/travis/scancodeExclusions
@@ -1,3 +1,6 @@
 # bundled files under MIT license; exclude from scan
 tests/fakengx.lua
 tests/fakeredis.lua
+tools/travis/platform.sh
+tools/travis/setup_lua.sh
+tools/travis/setenv_lua.sh

--- a/tools/travis/setenv_lua.sh
+++ b/tools/travis/setenv_lua.sh
@@ -1,3 +1,25 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2014 Alexey Melnichuk
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 export PATH=${PATH}:$HOME/.lua:$HOME/.local/bin:${TRAVIS_BUILD_DIR}/install/luarocks/bin
 bash ./tools/travis/setup_lua.sh
 eval `$HOME/.lua/luarocks path`

--- a/tools/travis/setenv_lua.sh
+++ b/tools/travis/setenv_lua.sh
@@ -1,0 +1,3 @@
+export PATH=${PATH}:$HOME/.lua:$HOME/.local/bin:${TRAVIS_BUILD_DIR}/install/luarocks/bin
+bash ./tools/travis/setup_lua.sh
+eval `$HOME/.lua/luarocks path`

--- a/tools/travis/setup_lua.sh
+++ b/tools/travis/setup_lua.sh
@@ -1,4 +1,25 @@
 #! /bin/bash
+# The MIT License (MIT)
+
+# Copyright (c) 2014 Alexey Melnichuk
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 
 # A script for setting up environment for travis-ci testing.
 # Sets up Lua and Luarocks.

--- a/tools/travis/setup_lua.sh
+++ b/tools/travis/setup_lua.sh
@@ -1,0 +1,122 @@
+#! /bin/bash
+
+# A script for setting up environment for travis-ci testing.
+# Sets up Lua and Luarocks.
+# LUA must be "lua5.1", "lua5.2" or "luajit".
+# luajit2.0 - master v2.0
+# luajit2.1 - master v2.1
+
+set -eufo pipefail
+
+LUAJIT_VERSION="2.0.4"
+LUAJIT_BASE="LuaJIT-$LUAJIT_VERSION"
+
+source ./tools/travis/platform.sh
+
+LUA_HOME_DIR=$TRAVIS_BUILD_DIR/install/lua
+
+LR_HOME_DIR=$TRAVIS_BUILD_DIR/install/luarocks
+
+mkdir $HOME/.lua
+
+LUAJIT="no"
+
+if [ "$PLATFORM" == "macosx" ]; then
+  if [ "$LUA" == "luajit" ]; then
+    LUAJIT="yes";
+  fi
+  if [ "$LUA" == "luajit2.0" ]; then
+    LUAJIT="yes";
+  fi
+  if [ "$LUA" == "luajit2.1" ]; then
+    LUAJIT="yes";
+  fi;
+elif [ "$(expr substr $LUA 1 6)" == "luajit" ]; then
+  LUAJIT="yes";
+fi
+
+mkdir -p "$LUA_HOME_DIR"
+
+if [ "$LUAJIT" == "yes" ]; then
+
+  if [ "$LUA" == "luajit" ]; then
+    curl --location https://github.com/LuaJIT/LuaJIT/archive/v$LUAJIT_VERSION.tar.gz | tar xz;
+  else
+    git clone https://github.com/LuaJIT/LuaJIT.git $LUAJIT_BASE;
+  fi
+
+  cd $LUAJIT_BASE
+
+  if [ "$LUA" == "luajit2.1" ]; then
+    git checkout v2.1;
+    # force the INSTALL_TNAME to be luajit
+    perl -i -pe 's/INSTALL_TNAME=.+/INSTALL_TNAME= luajit/' Makefile
+  fi
+
+  make && make install PREFIX="$LUA_HOME_DIR"
+
+  ln -s $LUA_HOME_DIR/bin/luajit $HOME/.lua/luajit
+  ln -s $LUA_HOME_DIR/bin/luajit $HOME/.lua/lua;
+
+else
+
+  if [ "$LUA" == "lua5.1" ]; then
+    curl http://www.lua.org/ftp/lua-5.1.5.tar.gz | tar xz
+    cd lua-5.1.5;
+  elif [ "$LUA" == "lua5.2" ]; then
+    curl http://www.lua.org/ftp/lua-5.2.4.tar.gz | tar xz
+    cd lua-5.2.4;
+  elif [ "$LUA" == "lua5.3" ]; then
+    curl http://www.lua.org/ftp/lua-5.3.2.tar.gz | tar xz
+    cd lua-5.3.2;
+  fi
+
+  # Build Lua without backwards compatibility for testing
+  perl -i -pe 's/-DLUA_COMPAT_(ALL|5_2)//' src/Makefile
+  make $PLATFORM
+  make INSTALL_TOP="$LUA_HOME_DIR" install;
+
+  ln -s $LUA_HOME_DIR/bin/lua $HOME/.lua/lua
+  ln -s $LUA_HOME_DIR/bin/luac $HOME/.lua/luac;
+
+fi
+
+cd $TRAVIS_BUILD_DIR
+
+lua -v
+
+LUAROCKS_BASE=luarocks-$LUAROCKS
+
+curl --location http://luarocks.org/releases/$LUAROCKS_BASE.tar.gz | tar xz
+
+cd $LUAROCKS_BASE
+
+if [ "$LUA" == "luajit" ]; then
+  ./configure --lua-suffix=jit --with-lua-include="$LUA_HOME_DIR/include/luajit-2.0" --prefix="$LR_HOME_DIR";
+elif [ "$LUA" == "luajit2.0" ]; then
+  ./configure --lua-suffix=jit --with-lua-include="$LUA_HOME_DIR/include/luajit-2.0" --prefix="$LR_HOME_DIR";
+elif [ "$LUA" == "luajit2.1" ]; then
+  ./configure --lua-suffix=jit --with-lua-include="$LUA_HOME_DIR/include/luajit-2.1" --prefix="$LR_HOME_DIR";
+else
+  ./configure --with-lua="$LUA_HOME_DIR" --prefix="$LR_HOME_DIR"
+fi
+
+make build && make install
+
+ln -s $LR_HOME_DIR/bin/luarocks $HOME/.lua/luarocks
+
+cd $TRAVIS_BUILD_DIR
+
+luarocks --version
+
+rm -rf $LUAROCKS_BASE
+
+if [ "$LUAJIT" == "yes" ]; then
+  rm -rf $LUAJIT_BASE;
+elif [ "$LUA" == "lua5.1" ]; then
+  rm -rf lua-5.1.5;
+elif [ "$LUA" == "lua5.2" ]; then
+  rm -rf lua-5.2.4;
+elif [ "$LUA" == "lua5.3" ]; then
+  rm -rf lua-5.3.2;
+fi


### PR DESCRIPTION
This is a rather extensive PR. Apologies for that.

There were a number of issues discovered upon upgrading from OpenResty 1.13.x to 1.15.x or 1.17.x. The primary problem was that module-level functions weren't declared `local` in previous iterations of apigateway. This didn't seem to matter when we were on OpenResty 1.13.x, although some impact can't be ruled out in high-throughput production environments.

OpenResty 1.15 and 1.17 include newer versions of LuaJIT, which seem to be much more sensitive to these types of scope leaks, perhaps due to improved efficiency. Nothing jumped out at me after scanning the commit logs for LuaJIT, but this seems the most likely cause.

OpenResty 1.15 also began emitting warnings about global scope `_G` usage, so this PR corrects all of those warnings. Since Lua cares about the order in which things are defined (it's not Javascript, after all), the order of functions across many files has been altered to account for this.

There are some background around why this change is necessary [here](https://www.luafaq.org/#T1.37.1) and [here](http://lua-users.org/wiki/LuaModuleFunctionCritiqued).

Essentially the changes here are:
- Upgrade OpenResty to 1.17.x (see #379)
- Fix function and variable scoping problems to prevent accidental leakage / overwriting in the global scope (see #378)
- Added the `lua-releng` tool to the Travis build in order to prevent scope issues from being introduced in the future
- Fixed a few typo bugs that were discovered during the scoping fixes
- Prevent tools from being sent to the Docker build