### PR TITLE
fix(rclone): use official install mechanism

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -250,7 +250,7 @@ RUN echo " ... installing cjose ... " \
 
 ENV CONFIG_SUPERVISOR_VERSION 1.0.1-RC1
 COPY build_config_supervisor.sh /tmp/build_config_supervisor.sh
-RUN sh +x /tmp/build_config_supervisor.sh
+RUN sh +x -e /tmp/build_config_supervisor.sh
 
 # Add standard gateway configuration
 FROM base as apigateway

--- a/build_config_supervisor.sh
+++ b/build_config_supervisor.sh
@@ -39,8 +39,12 @@ GOPATH=/tmp/go/vendor:/tmp/go-src CGO_ENABLED=0 GOOS=linux /usr/lib/go/bin/godep
 mv /tmp/go/api-gateway-config-supervisor /usr/local/sbin/
 
 echo "installing rclone sync ... "
-go get github.com/ncw/rclone
-mv /usr/lib/go/bin/rclone /usr/local/sbin/
+mkdir -p /tmp/rclone
+cd /tmp/rclone
+curl -O https://downloads.rclone.org/rclone-current-linux-amd64.zip
+unzip rclone-current-linux-amd64.zip
+cd rclone-*-linux-amd64
+mv ./rclone /usr/local/sbin/
 mkdir -p /root/.config/rclone/
 cat <<EOF > /root/.config/rclone/rclone.conf
 [local]
@@ -50,6 +54,7 @@ EOF
 
 echo " cleaning up ... "
 rm -rf /usr/lib/go/bin/src
+rm -rf /tmp/rclone
 rm -rf /tmp/go
 rm -rf /tmp/go-src
 rm -rf /usr/lib/go/bin/pkg/


### PR DESCRIPTION
Connected to https://github.com/apache/openwhisk-devtools/issues/322

I can confirm that this fixes the rclone binary, but I haven't tested it against the Docker Compose build that openwhisk-devtools is using, so I can't confirm whether that then works as intended.

I also ensured that the Docker build will fail if rclone can't be installed, which should protect us from this occurring in the future.

Here, rclone actually runs
```
$ docker run apigateway rclone mkdir minio:api-gateway
2020/08/06 21:36:28 Failed to create file system for "minio:api-gateway": didn't find section in config file
```