### PR TITLE
Allow trailing non-alphanumeric character in path params

### DIFF
--- a/conf.d/managed_endpoints.conf
+++ b/conf.d/managed_endpoints.conf
@@ -57,7 +57,7 @@ server {
         ';
     }
 
-    location ~ "^/api/([a-zA-Z0-9\-]+)/([a-zA-Z0-9\-\/\.\_\{\} ]+)(\\b)" {
+    location ~ "^/api/([a-zA-Z0-9\-]+)/([a-zA-Z0-9\-\/\.\_\{\} ]*[a-zA-Z0-9\-\/\.\_\{\}])" {
         set $upstream https://172.17.0.1;
         set $tenant $1;
         set $tenantNamespace '';


### PR DESCRIPTION
Updating parsing for $gatewayPath in allow for trailing non-alphanumeric characters in path parameters.